### PR TITLE
Adding --submodules flag for git

### DIFF
--- a/src/lix/cli/Cli.hx
+++ b/src/lix/cli/Cli.hx
@@ -15,6 +15,7 @@ class Cli {
     var version = Macro.getVersion();
     var silent = args.remove('--silent'),
         force = args.remove('--force'),
+        submodules = args.remove('--submodules'),
         global = args.remove('--global') || args.remove('-g');
 
     var scope = Scope.seek({ cwd: if (global) Scope.DEFAULT_ROOT else null });
@@ -39,8 +40,8 @@ class Cli {
         });
 
     var haxelibUrl = new tink.url.Host(grab('--haxelib-url'));
-    
-    var sources:Array<ArchiveSource> = [Web, new Lix(), new Haxelib(haxelibUrl), github, gitlab, new Git(github, gitlab, scope)];
+
+    var sources:Array<ArchiveSource> = [Web, new Lix(), new Haxelib(haxelibUrl), github, gitlab, new Git(github, gitlab, scope, submodules)];
     var resolvers:Map<String, ArchiveSource> = [for (s in sources) for (scheme in s.schemes()) scheme => s];
 
     function resolve(url:Url):Promise<ArchiveJob>

--- a/src/lix/client/Archives.hx
+++ b/src/lix/client/Archives.hx
@@ -27,6 +27,7 @@ typedef ArchiveJob = {
   var lib(default, null):LibVersion;
   var dest(default, null):ArchiveDestination;
 
+  @:optional var arguments(default, null):Array<String>;
   @:optional var kind(default, null):Null<ArchiveKind>;
 }
 

--- a/src/lix/client/Libraries.hx
+++ b/src/lix/client/Libraries.hx
@@ -140,9 +140,12 @@ using haxe.Json;
 
       function saveHxml<T>(?value:T):Promise<T> 
         return (function () {
+          var arguments = a.job.arguments == null ? [] : a.job.arguments.copy();
+          arguments.push('--silent');
+
           var directives = [
             '-D $name=$version',
-            '# @$INSTALL: lix --silent download "${a.job.normalized}" into ${a.relRoot}',            
+            '# @$INSTALL: lix ${arguments.join(' ')} download "${a.job.normalized}" into ${a.relRoot}',            
           ];
 
           switch infos.postDownload {


### PR DESCRIPTION
While using git for lime, some commands like `lime rebuild mac` won't works because of missing submodules from the repo. This add a flag that basically call
`git submodule update --init --recursive`

Without submodules, this means we have to include binary blob from git repo for custom branches.

Usage:
`lix install git:git@github.com:starburst997/lime#jd-renderer --submodules`