### PR TITLE
Fix Lix looking like software from 2009

### DIFF
--- a/src/lix/cli/Cli.hx
+++ b/src/lix/cli/Cli.hx
@@ -72,7 +72,7 @@ class Cli {
       #end
     );
 
-    Command.dispatch(args, 'lix - Libraries for haXe (v$version)', [
+    Command.dispatch(args, 'lix - Libraries for Haxe (v$version)', [
       new Command('install', '<url> [as <lib[#ver]>]', 'install lib from specified url',
         function (args) 
           return 


### PR DESCRIPTION
I'm aware this isn't meant to be the old Haxe spelling, but rather the "Lix" abbrevation, but most people will only make the first connection...

See also https://github.com/lix-pm/lix.client/pull/34.