### PR TITLE
Flat flag for git source

### DIFF
--- a/src/lix/cli/Cli.hx
+++ b/src/lix/cli/Cli.hx
@@ -40,7 +40,7 @@ class Cli {
 
     var haxelibUrl = new tink.url.Host(grab('--haxelib-url'));
     var web = new Web([gitlab.intercept, github.intercept]);
-    var sources:Array<ArchiveSource> = [web, new Haxelib(haxelibUrl), github, gitlab, new Git(scope)];
+    var sources:Array<ArchiveSource> = [web, new Haxelib(haxelibUrl), github, gitlab, new Git(scope, flat)];
     var resolvers:Map<String, ArchiveSource> = [for (s in sources) for (scheme in s.schemes()) scheme => s];
 
     function resolve(url:Url):Promise<ArchiveJob>

--- a/src/lix/client/Archives.hx
+++ b/src/lix/client/Archives.hx
@@ -28,6 +28,7 @@ typedef ArchiveJob = {
   var dest(default, null):ArchiveDestination;
 
   @:optional var kind(default, null):Null<ArchiveKind>;
+  @:optional var arguments(default, null):Array<String>;
 }
 
 enum ArchiveDependency {

--- a/src/lix/client/Libraries.hx
+++ b/src/lix/client/Libraries.hx
@@ -7,6 +7,7 @@ import lix.api.Api;
 import haxeshim.Scope.*;
 
 using haxe.Json;
+using Lambda;
 
 @:tink class Libraries {
   
@@ -33,6 +34,8 @@ using haxe.Json;
               into = DownloadedArchive.path(path);
             case Computed(_):
               cacheFile = '${scope.libCache}/.cache/libNames/${DownloadedArchive.escape(a.url)}';
+              if (a.arguments != null && a.arguments.has('--flat'))
+                cacheFile += '_flat';
               if (cacheFile.exists()) 
                 into = cacheFile.getContent();
           }
@@ -144,11 +147,14 @@ using haxe.Json;
           }
           else
             Noise;
-
+            
       function saveHxml<T>(?value:T):Promise<T> {
+        var arguments = a.job.arguments == null ? [] : a.job.arguments.copy();
+        arguments.push('--silent');
+
         var directives = [
           '-D $name=$version',
-          '# @$INSTALL: lix --silent download "${a.job.normalized}" into ${a.relRoot}',            
+          '# @$INSTALL: lix ${arguments.join(' ')} download "${a.job.normalized}" into ${a.relRoot}',            
         ];
 
         switch infos.postDownload {


### PR DESCRIPTION
Hello,
I've been using @starburst997's fork for submodule support for a while but have been running into a few annoyances, mainly that you can't use the github and gitlab shorthand and that its a few versions behind at this point. This PR adds recursive cloning by default to git, github, and gitlab libraries with a `--flat` flag to opt out.

I moved away from downloading a zip archive for github and gitlab libraries since they use git-archive to generate the zips which don't include submodules, I instead re-used the downloader from the git class.
One thing I'm not sure how to handle is caching between recursive and non recursive installs. If for one project you install a library with the flat flag, but then want that same library but recursive in another project it will give you that cached flat version instead, the same is true vice-versa.

Cheers.