### PR TITLE
Short scheme "hl" for "haxelib"?

### DIFF
--- a/src/lix/client/sources/Haxelib.hx
+++ b/src/lix/client/sources/Haxelib.hx
@@ -22,7 +22,7 @@ private class Proxy extends haxe.remoting.AsyncProxy<lix.client.sources.haxelib.
     return getBaseUrl(options).resolve(url);
 
   public function schemes():Array<String>
-    return ['haxelib'];
+    return ['haxelib', 'hl'];
 
   public function processUrl(url:Url):Promise<ArchiveJob> 
     return 


### PR DESCRIPTION
For Haxe, haxelib is such a proeminent source for stable versions that
it seems to make sense to have "hl" scheme for "haxelib",
similar to the way we have "gh" for "github".

(Accustomed to "gh:", I almost always type "hl:" already...)