### PR TITLE
Don't specify URL when git fetch

### DIFF
--- a/src/lix/client/sources/Git.hx
+++ b/src/lix/client/sources/Git.hx
@@ -75,7 +75,7 @@ class Git {
               var repo = Path.join([scope.libCache, '.gitrepos', DownloadedArchive.escape(origin)]);
               var git = cli(repo);
               git.call(
-                if ('$repo/.git'.exists()) ['fetch', origin]
+                if ('$repo/.git'.exists()) ['fetch']
                 else ['clone', origin, '.']
               )
                 .next(_ -> git.call(['-c', 'advice.detachedHead=false', 'checkout', sha]))


### PR DESCRIPTION
Somehow doing so will not fetch info for new branches, making lix unable to install from a git branch