### PR TITLE
Install Haxe and Neko 64-bit on Windows x64 platform

### DIFF
--- a/src/lix/client/haxe/Switcher.hx
+++ b/src/lix/client/haxe/Switcher.hx
@@ -186,24 +186,7 @@ class Switcher {
     return
       'https://haxe.org/website-content/downloads/$version/downloads/haxe-$version-' + switch Sys.systemName() {
         case 'Windows':
-          var arch = '';
-          // #if nodejs
-          //   if (js.node.Os.arch().contains('64')) arch = '64';
-          // #elseif sys
-          //   if (version > "3.4.3" && version != "4.0.0-preview.1") {
-          //     var wmic = new sys.io.Process('WMIC OS GET osarchitecture /value');
-          //     try
-          //       switch wmic.stdout.readAll().toString() {
-          //         case v if (v.indexOf('64') >= 0):
-          //           arch = '64';
-          //         case _:
-          //       }
-          //     catch(_:Any) {}
-          //     wmic.close();
-          //   }
-          // #else
-          //   #error
-          // #end
+          final arch = version > "3.4.3" && version != "4.0.0-preview.1" && isWin64Platform() ? "64" : "";
           'win$arch.zip';
         case 'Mac': 'osx.tar.gz';
         default:
@@ -323,7 +306,9 @@ class Switcher {
         logger.info('Neko seems to be missing. Attempting download ...');
 
         (switch Sys.systemName() {
-          case 'Windows': Download.zip('https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-win.zip', 1, neko, logger);
+          case 'Windows':
+            final arch = isWin64Platform() ? "64" : "";
+            Download.zip('https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-win$arch.zip', 1, neko, logger);
           case 'Mac': Download.tar('https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-osx64.tar.gz', 1, neko, logger);
           default: Download.tar('https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-linux64.tar.gz', 1, neko, logger);
         }).next(function (x) {
@@ -333,4 +318,13 @@ class Switcher {
       }
   }
 
+  // https://docs.microsoft.com/en-us/archive/blogs/david.wang/howto-detect-process-bitness
+  static function isWin64Platform() {
+    for (environmentVariable in ["PROCESSOR_ARCHITECTURE", "PROCESSOR_ARCHITEW6432"]) {
+      final processorArchitecture = Sys.getEnv(environmentVariable);
+      if (processorArchitecture != null && processorArchitecture.contains("64")) return true;
+    }
+
+    return false;
+  }
 }


### PR DESCRIPTION
Same as #158, but without relying on `sys.io.Process`.