### PR TITLE
Fix #194 - erroneously trying to install ndlls as haxelibs

### DIFF
--- a/src/lix/client/Libraries.hx
+++ b/src/lix/client/Libraries.hx
@@ -87,7 +87,7 @@ using haxe.Json;
         case Success(args): [for (a in args) a.val];
         case Failure(_.errors[0] => e): new Error(e.code, e.message);
       })
-      .next(args -> [for (i => a in args) if (a == '-lib') args[i + 1]]);
+      .next(args -> [for (i => a in args) if (a == '-lib' && Args.getNdll(args[i + 1]) == None) args[i + 1]]);
   }
 
 


### PR DESCRIPTION
I debugged my issue #194 and found the problem -- installFromLibHxml() returns a list of recursive dependencies, obtained by collecting all -lib flags in the args. It needs to filter out args in the form `-lib ndll:<path>` because those aren't dependencies that can be installed via installFromLibHxml().

I believe this fixes the root of the problem, though it could probably be implemented cleaner, as `args[i + 1]` ends up repeated within the line.