### PR TITLE
Use neko v2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lix",
-    "version": "15.12.1",
+    "version": "15.12.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "lix",
-            "version": "15.12.1",
+            "version": "15.12.2",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,17 +16,16 @@
                 "neko": "bin/nekoshim.js"
             },
             "devDependencies": {
-                "@zeit/ncc": "^0.20.4",
+                "@vercel/ncc": "^0.38.1",
                 "graceful-fs": "^4.1.15",
                 "tar": "^6.0.1",
                 "yauzl": "github:lix-pm/yauzl"
             }
         },
-        "node_modules/@zeit/ncc": {
-            "version": "0.20.5",
-            "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz",
-            "integrity": "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==",
-            "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
+        "node_modules/@vercel/ncc": {
+            "version": "0.38.1",
+            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+            "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
             "dev": true,
             "bin": {
                 "ncc": "dist/ncc/cli.js"
@@ -153,10 +152,10 @@
         }
     },
     "dependencies": {
-        "@zeit/ncc": {
-            "version": "0.20.5",
-            "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz",
-            "integrity": "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==",
+        "@vercel/ncc": {
+            "version": "0.38.1",
+            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+            "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
             "dev": true
         },
         "buffer-crc32": {
@@ -248,6 +247,7 @@
         },
         "yauzl": {
             "version": "git+ssh://git@github.com/lix-pm/yauzl.git#94fdf00d3918db46f4d2d0c4b0c1ab50f262dcdc",
+            "integrity": "sha512-Coz7mKLBLHqw5rcGCwpLqRh/jj9x5ByevuoCn11jwMtV2Fx5Api46k2KGje9cp+sXo9+bik6BJRwLhu5HrUEoQ==",
             "dev": true,
             "from": "yauzl@github:lix-pm/yauzl",
             "requires": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "url": "git+https://github.com/lix-pm/lix.git"
     },
     "devDependencies": {
-        "@zeit/ncc": "^0.20.4",
+        "@vercel/ncc": "^0.38.1",
         "graceful-fs": "^4.1.15",
         "tar": "^6.0.1",
         "yauzl": "github:lix-pm/yauzl"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lix",
-    "version": "15.12.1",
+    "version": "15.12.2",
     "bin": {
         "lix": "bin/lix.js",
         "haxe": "bin/haxeshim.js",

--- a/src/lix/client/haxe/Switcher.hx
+++ b/src/lix/client/haxe/Switcher.hx
@@ -320,12 +320,15 @@ class Switcher {
 
         logger.info('Neko seems to be missing. Attempting download ...');
 
-        (switch [Sys.systemName(), js.Node.process.arch] {
-          case ['Windows', _]: Download.zip('https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-win.zip', 1, neko, logger);
-          case ['Mac', _]: Download.tar('https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-osx64.tar.gz', 1, neko, logger);
-          case [_, 'arm64']: Download.tar('https://build.haxe.org/builds/neko/linux-arm64/neko_latest.tar.gz', 1, neko, logger);
-          default: Download.tar('https://github.com/HaxeFoundation/neko/releases/download/v2-3-0/neko-2.3.0-linux64.tar.gz', 1, neko, logger);
-        }).next(function (x) {
+        var getUrl = (platformArchive:String)->'https://github.com/HaxeFoundation/neko/releases/download/v2-4-0/neko-2.4.0-${platformArchive}';
+        var downloadArchive:(peel:Int, into:String, logger:Logger)->Promise<Download.Directory> = switch [Sys.systemName(), js.Node.process.arch] {
+          case ['Windows', _]: Download.zip.bind(getUrl('win.zip'));
+          case ['Mac', _]: Download.tar.bind(getUrl('osx-universal.tar.gz'));
+          case [_, 'arm64']: Download.tar.bind(getUrl('linux-arm64.tar.gz'));
+          default: Download.tar.bind(getUrl('linux64.tar.gz'));
+        }
+
+        downloadArchive(1, neko, logger).next(function (x) {
           logger.success('done');
           return x;
         });


### PR DESCRIPTION
Use neko v2.4.0. This version of neko contains universal binaries for MacOSs and can be run on M(arm64) processors. 